### PR TITLE
include get_plain_chain_date in the exposed functions of the lib

### DIFF
--- a/yoptions/__init__.py
+++ b/yoptions/__init__.py
@@ -3,6 +3,7 @@ from .main import get_underlying_price
 from .main import get_plain_option_ticker
 from .main import get_plain_option
 from .main import get_plain_chain
+from .main import get_plain_chain_date
 from .main import get_historical_option
 from .main import get_historical_option_ticker
 from .main import get_chain_greeks


### PR DESCRIPTION
In order to access the option chain for a specific expiration date, the existing function must be exposed